### PR TITLE
fix: check for user info nil

### DIFF
--- a/ios/RNWatch/RNWatch.m
+++ b/ios/RNWatch/RNWatch.m
@@ -575,7 +575,12 @@ RCT_EXPORT_METHOD(dequeueUserInfo:
 - (void)session:(WCSession *)session didFinishUserInfoTransfer:(WCSessionUserInfoTransfer *)userInfoTransfer error:(NSError *)error {
     if (error) {
         NSLog(@"User info transfer error: %@ %@", error, [error userInfo]);
-      [self dispatchEventWithName:EVENT_WATCH_USER_INFO_ERROR body:@{@"userInfo": [userInfoTransfer userInfo], @"error": dictionaryFromError(error)}];
+        NSMutableDictionary *body = NSMutableDictionary.new;
+        body[@"error"] = dictionaryFromError(error);
+        if ([userInfoTransfer userInfo]) {
+            body[@"userInfo"] = [userInfoTransfer userInfo];
+        }
+        [self dispatchEventWithName:EVENT_WATCH_USER_INFO_ERROR body:body];
     }
 }
 


### PR DESCRIPTION
I'm not sure about the exact circumstances, but at times my iOS app crashed due to the following error (obtained via Sentry):

```
NSInvalidArgumentException: *** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[0]
  ?, in -[RNWatch session:didFinishUserInfoTransfer:error:]
```

It seems that the `[userInfoTransfer userInfo]` property can be `nil` at times, but I do not understand when and why.

Anyway, this PR should at least prevent a crash.